### PR TITLE
Swith to Polyphony fiber connection

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -4,30 +4,30 @@
 
 require 'bundler/setup'
 require 'sequel'
-# require 'polyphony'
-# require 'polyphony/adapters/sequel'
-# require 'polyphony/adapters/postgres'
+require 'polyphony'
+require 'polyphony/adapters/sequel'
+require 'polyphony/adapters/postgres'
 
 URL = ENV['SEQUEL_URL'] || 'postgres://localhost/test'
 
 x = 10000
 query_count = 0
 
-db = Sequel.connect(URL)
-x.times { query_count += 1; db.execute('select 1 as test') }
-t0 = Time.now
-puts "query rate: #{query_count / (Time.now - t0)} reqs/s; count = #{query_count}"
-
-# spin do
-#   db = Sequel.connect(URL)
-#   x.times { query_count += 1; db.execute('select 1 as test') }
-# end
-
-# spin do
-#   db = Sequel.connect(URL)
-#   x.times { query_count += 1; db.execute('select 2 as test') }
-# end
-
+# db = Sequel.connect(URL)
+# x.times { query_count += 1; db.execute('select 1 as test') }
 # t0 = Time.now
-# Fiber.current.await_all_children
 # puts "query rate: #{query_count / (Time.now - t0)} reqs/s; count = #{query_count}"
+
+spin do
+  db = Sequel.connect(URL)
+  x.times { query_count += 1; db.execute('select 1 as test') }
+end
+
+spin do
+  db = Sequel.connect(URL)
+  x.times { query_count += 1; db.execute('select 2 as test') }
+end
+
+t0 = Time.now
+Fiber.current.await_all_children
+puts "query rate: #{query_count / (Time.now - t0)} reqs/s; count = #{query_count}"


### PR DESCRIPTION
The last working [run](https://github.com/v-kolesnikov/bug-sequel-fibers/actions/runs/6898658818/job/18769026826)


The current version fails with ``ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `for_fd': Bad file descriptor - fstat(2) (Errno::EBADF)``:

```
$ ruby --verbose run.rb
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/thread.rb:118: warning: method redefined; discarding old value
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/fiber.rb:169: warning: method redefined; discarding old raise
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:90: warning: method redefined; discarding old copy_stream
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:228: warning: method redefined; discarding old ungetc
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:236: warning: method redefined; discarding old ungetbyte
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:259: warning: method redefined; discarding old readpartial
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:308: warning: method redefined; discarding old each_line
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:432: warning: method redefined; discarding old wait_readable
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/io.rb:450: warning: method redefined; discarding old wait_writable
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:32: warning: method redefined; discarding old accept
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:51: warning: method redefined; discarding old connect
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:137: warning: method redefined; discarding old recvfrom
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:240: warning: method redefined; discarding old initialize
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:449: warning: method redefined; discarding old initialize
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/extensions/socket.rb:702: warning: method redefined; discarding old send
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/adapters/postgres.rb:8: warning: method redefined; discarding old connect
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg.rb:62: warning: previous definition of connect was here
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/adapters/postgres.rb:60: warning: method redefined; discarding old block
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/polyphony-1.6/lib/polyphony/adapters/postgres.rb:75: warning: method redefined; discarding old transaction
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:305: warning: previous definition of transaction was here
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `for_fd': Errno::EBADF: Bad file descriptor - fstat(2) (Sequel::DatabaseConnectionError)
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `socket_io'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `async_connect_or_reset'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:824:in `connect_to_hosts'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:759:in `new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/adapters/postgres.rb:231:in `connect'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:248:in `new_connection'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/connection_pool.rb:161:in `make_new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:293:in `synchronize'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:302:in `test_connection'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/misc.rb:188:in `initialize'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:57:in `new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:57:in `connect'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/core.rb:124:in `connect'
	from run.rb:22:in `block in <main>'
	from run.rb:21:in `<main>'
	from run.rb:21:in `<main>'
/home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `for_fd': Bad file descriptor - fstat(2) (Errno::EBADF)
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `socket_io'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:669:in `async_connect_or_reset'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:824:in `connect_to_hosts'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/pg-1.5.4/lib/pg/connection.rb:759:in `new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/adapters/postgres.rb:231:in `connect'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:248:in `new_connection'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/connection_pool.rb:161:in `make_new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:293:in `synchronize'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:302:in `test_connection'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/misc.rb:188:in `initialize'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:57:in `new'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/database/connecting.rb:57:in `connect'
	from /home/runner/work/bug-sequel-fibers/bug-sequel-fibers/vendor/bundle/ruby/3.1.0/gems/sequel-5.74.0/lib/sequel/core.rb:124:in `connect'
	from run.rb:22:in `block in <main>'
	from run.rb:21:in `<main>'
Error: Process completed with exit code 1.
```